### PR TITLE
Upgrading mongo client to version compatible with server v8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb-reactive</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mongodb</groupId>
+					<artifactId>mongodb-driver-reactivestreams</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-reactivestreams</artifactId>
+			<version>5.2.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Mongo client comes via `spring-boot-starter-data-mongodb-reactive` (it uses mongo client v 4.11.1). I checked the latest version of `spring-boot-starter-data-mongodb-reactive` but it also comes with the same version of mongo client. Thus I decided to go with adding the explicit dependency. Is that the way to go @bioinsilico ?

Note I couldn't test it because I couldn't start the server locally, but the error seems unrelated: `Parameter 0 of constructor in org.rcsb.rcsbsequencecoordinates.controller.GraphQlRSocketController required a bean of type 'org.springframework.graphql.ExecutionGraphQlService' that could not be found.`