### PR TITLE
K8s and workflow changes

### DIFF
--- a/.github/workflows/workflow-java.yaml
+++ b/.github/workflows/workflow-java.yaml
@@ -1,0 +1,12 @@
+name: Run CI/CD Workflow
+
+on:
+  push:
+    paths-ignore:
+      - "k8s/**"
+  workflow_dispatch:
+
+jobs:
+  run-workflow:
+    name: "Run automated workflow"
+    uses: rcsb/devops-cicd-github-actions/.github/workflows/workflow-java.yaml@master

--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: rcsb-sequence-coordinates
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helm_chart.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helm_chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "helm_chart.labels" -}}
+helm.sh/chart: {{ include "helm_chart.chart" . }}
+{{ include "helm_chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helm_chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Persistent volume name. Utilize namespace aware naming to allow deployments of cluster resources for different environments.
+*/}}
+{{- define "helm_chart.pvname" -}}
+{{- printf "%s-%s" .Release.Namespace .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+ConfigMap resource name. Ensure names conform to character limits in Kubernetes
+*/}}
+{{- define "helm_chart.configmapName" -}}
+{{- printf "%s-config" (include "helm_chart.fullname" . | trunc 56 | trimSuffix "-") }}
+{{- end }}

--- a/k8s/helm/templates/configmap.yaml
+++ b/k8s/helm/templates/configmap.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "helm_chart.fullname" . }}-config
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+data:
+{{- range $path, $config := .Values.seqcoordAppProperties }}
+  {{ $path }}: |
+{{ $config | indent 4 }}
+{{- end -}}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -57,10 +57,8 @@ spec:
             - mountPath: /var/www/log4j2.xml
               subPath: log4j2.xml
               name: {{ include "helm_chart.fullname" $ }}-config
-            # - mountPath: /elastic/apm/agent
-            #   name: elastic-apm-agent
             - mountPath: /var/www/seqcoordAppProperties.app.properties
-              subPath: seqcoordAppProperties.{{ . }}.app.properties
+              subPath: seqcoordinates.{{ . }}.app.properties
               name: {{ include "helm_chart.fullname" $ }}-secret
           env:
             - name: JDK_JAVA_OPTIONS
@@ -72,20 +70,4 @@ spec:
         - name: {{ include "helm_chart.fullname" $ }}-secret
           secret:
             secretName: {{ include "helm_chart.fullname" $ }}-secret
-          # livenessProbe:
-          #   initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
-          #   failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
-          #   periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
-          #   httpGet:
-          #     path: {{ $.Values.livenessProbe.http.path }}
-          #     port: {{ $.Values.service.containerPort }}
-          # readinessProbe:
-          #   initialDelaySeconds: {{ $.Values.initialReadinessDelaySeconds }}
-          #   failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
-          #   periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
-          #   httpGet:
-          #     path: {{ $.Values.readinessProbe.http.path }}
-          #     port: {{ $.Values.service.containerPort }}
-          # resources:
-          #   {{- toYaml $.Values.resources | nindent 12 }}
 {{- end }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           #       secretKeyRef:
           #         name: {{ include "rcsb-borrego.fullname" $ }}-secret
           #         key: apm_secret_token
-      volumes:
-        - name: elastic-apm-agent
-          emptyDir: { }
+      # volumes:
+      #   - name: elastic-apm-agent
+      #     emptyDir: { }
 {{- end }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -53,20 +53,20 @@ spec:
             - name: http
               containerPort: {{ $.Values.service.containerPort }}
               protocol: TCP
-          livenessProbe:
-            initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
-            failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
-            periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
-            httpGet:
-              path: {{ $.Values.livenessProbe.http.path }}
-              port: {{ $.Values.service.containerPort }}
-          readinessProbe:
-            initialDelaySeconds: {{ $.Values.initialReadinessDelaySeconds }}
-            failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
-            periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
-            httpGet:
-              path: {{ $.Values.readinessProbe.http.path }}
-              port: {{ $.Values.service.containerPort }}
+          # livenessProbe:
+          #   initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
+          #   failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
+          #   periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
+          #   httpGet:
+          #     path: {{ $.Values.livenessProbe.http.path }}
+          #     port: {{ $.Values.service.containerPort }}
+          # readinessProbe:
+          #   initialDelaySeconds: {{ $.Values.initialReadinessDelaySeconds }}
+          #   failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
+          #   periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
+          #   httpGet:
+          #     path: {{ $.Values.readinessProbe.http.path }}
+          #     port: {{ $.Values.service.containerPort }}
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
           # env:

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -69,6 +69,9 @@ spec:
         - name: {{ include "helm_chart.fullname" $ }}-config
           configMap:
             name: {{ include "helm_chart.fullname" $ }}-config
+        - name: {{ include "rcsb-borrego.fullname" $ }}-secret
+          secret:
+            secretName: {{ include "rcsb-borrego.fullname" $ }}-secret
           # livenessProbe:
           #   initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
           #   failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    {{- include "helm_charto.selectorLabels" $ | nindent 20 }}
+                    {{- include "helm_chart.selectorLabels" $ | nindent 20 }}
                 topologyKey: kubernetes.io/hostname
               weight: 1
       imagePullSecrets:

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -13,6 +13,13 @@ spec:
     matchLabels:
       {{- include "helm_chart.selectorLabels" $ | nindent 6 }}
       rcsb.org/path: {{ . | quote }}
+  strategy:
+    type: {{ $.Values.deploymentStrategy.type }}
+    {{- if eq $.Values.deploymentStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ $.Values.deploymentStrategy.maxSurge }}
+      maxUnavailable: {{ $.Values.deploymentStrategy.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       {{- with $.Values.podAnnotations }}
@@ -46,6 +53,22 @@ spec:
             - name: http
               containerPort: {{ $.Values.service.containerPort }}
               protocol: TCP
+          volumeMounts:
+            - mountPath: /var/www/log4j2.xml
+              subPath: log4j2.xml
+              name: {{ include "helm_chart.fullname" $ }}-config
+            # - mountPath: /elastic/apm/agent
+            #   name: elastic-apm-agent
+            # - mountPath: /usr/local/tomcat/conf/log4j2.xml
+            #   subPath: log4j2.xml
+            #   name: {{ include "helm_chart.fullname" $ }}-config
+            # - mountPath: /var/www/seqcoordAppProperties.app.properties
+            #   subPath: seqcoordAppProperties.{{ . }}.app.properties
+            #   name: {{ include "helm_chart.fullname" $ }}-secret
+          volumes:
+            - name: {{ include "helm_chart.fullname" $ }}-config
+              configMap:
+                name: {{ include "helm_chart.fullname" $ }}-config
           # livenessProbe:
           #   initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
           #   failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
         - name: {{ $.Values.imagePullSecrets }}
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: elastic-java-agent
+          image: {{ $.Values.elasticAPM.elasticAPMImage }}
+          volumeMounts:
+            - mountPath: /elastic/apm/agent
+              name: elastic-apm-agent
+          command: [ 'cp', '-v', '/usr/agent/elastic-apm-agent.jar', '/elastic/apm/agent' ]
       containers:
         - name: {{ $.Chart.Name }}
           securityContext:
@@ -60,9 +67,28 @@ spec:
             - mountPath: /var/www/borrego.app.properties
               subPath: seqcoordinates.{{ . }}.app.properties
               name: {{ include "helm_chart.fullname" $ }}-secret
+            - mountPath: /elastic/apm/agent
+              name: elastic-apm-agent
           env:
             - name: JDK_JAVA_OPTIONS
               value: {{ $.Values.javaOptions }}
+            - name: JAVA_TOOL_OPTIONS
+              value: -javaagent:/elastic/apm/agent/elastic-apm-agent.jar
+            - name: ELASTIC_APM_SERVER_URL
+              value: {{ $.Values.elasticAPM.elasticAPMServerUrl }}
+            - name: ELASTIC_APM_SERVICE_NAME
+              value: seqcoord
+            - name: ELASTIC_APM_APPLICATION_PACKAGES
+              value: org.rcsb
+            - name: ELASTIC_APM_ENVIRONMENT
+              value: {{ $.Values.elasticAPM.elasticAPMEnvironment }}
+            - name: ELASTIC_APM_CAPTURE_BODY
+              value: transactions
+            - name: ELASTIC_APM_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "helm_chart.fullname" $ }}-secret
+                  key: apm_secret_token
       volumes:
         - name: {{ include "helm_chart.fullname" $ }}-config
           configMap:
@@ -70,4 +96,6 @@ spec:
         - name: {{ include "helm_chart.fullname" $ }}-secret
           secret:
             secretName: {{ include "helm_chart.fullname" $ }}-secret
+        - name: elastic-apm-agent
+          emptyDir: { }
 {{- end }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     rcsb.org/path: {{ . | quote }}
 spec:
   replicas: {{ $.Values.replicaCount }}
+  revisionHistoryLimit: {{ $.Values.revisionHistoryLimit}}
   selector:
     matchLabels:
       {{- include "helm_chart.selectorLabels" $ | nindent 6 }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -65,10 +65,10 @@ spec:
             # - mountPath: /var/www/seqcoordAppProperties.app.properties
             #   subPath: seqcoordAppProperties.{{ . }}.app.properties
             #   name: {{ include "helm_chart.fullname" $ }}-secret
-          volumes:
-            - name: {{ include "helm_chart.fullname" $ }}-config
-              configMap:
-                name: {{ include "helm_chart.fullname" $ }}-config
+      volumes:
+        - name: {{ include "helm_chart.fullname" $ }}-config
+          configMap:
+            name: {{ include "helm_chart.fullname" $ }}-config
           # livenessProbe:
           #   initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
           #   failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
@@ -83,6 +83,6 @@ spec:
           #   httpGet:
           #     path: {{ $.Values.readinessProbe.http.path }}
           #     port: {{ $.Values.service.containerPort }}
-          resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+          # resources:
+          #   {{- toYaml $.Values.resources | nindent 12 }}
 {{- end }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -1,0 +1,81 @@
+{{- range tuple "a" "b" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helm_chart.fullname" $ }}-{{ . }}
+  labels:
+    {{- include "helm_chart.labels" $ | nindent 4 }}
+    rcsb.org/path: {{ . | quote }}
+spec:
+  replicas: {{ $.Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "helm_chart.selectorLabels" $ | nindent 6 }}
+      rcsb.org/path: {{ . | quote }}
+  template:
+    metadata:
+      {{- with $.Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "helm_chart.selectorLabels" $ | nindent 8 }}
+        rcsb.org/path: {{ . | quote }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "helm_charto.selectorLabels" $ | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+      imagePullSecrets:
+        - name: {{ $.Values.imagePullSecrets }}
+      securityContext:
+        {{- toYaml $.Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: elastic-java-agent
+          image: {{ $.Values.elasticAPM.elasticAPMImage }}
+          volumeMounts:
+            - mountPath: /elastic/apm/agent
+              name: elastic-apm-agent
+          command: [ 'cp', '-v', '/usr/agent/elastic-apm-agent.jar', '/elastic/apm/agent' ]
+      containers:
+        - name: {{ $.Chart.Name }}
+          securityContext:
+            {{- toYaml $.Values.securityContext | nindent 12 }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $.Values.service.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
+            failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
+            periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
+            httpGet:
+              path: {{ $.Values.livenessProbe.http.path }}
+              port: {{ $.Values.service.containerPort }}
+          readinessProbe:
+            initialDelaySeconds: {{ $.Values.initialReadinessDelaySeconds }}
+            failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
+            periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
+            httpGet:
+              path: {{ $.Values.readinessProbe.http.path }}
+              port: {{ $.Values.service.containerPort }}
+          resources:
+            {{- toYaml $.Values.resources | nindent 12 }}
+          # env:
+          #   - name: ELASTIC_APM_SECRET_TOKEN
+          #     valueFrom:
+          #       secretKeyRef:
+          #         name: {{ include "rcsb-borrego.fullname" $ }}-secret
+          #         key: apm_secret_token
+      volumes:
+        - name: elastic-apm-agent
+          emptyDir: { }
+{{- end }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -60,6 +60,21 @@ spec:
             - name: http
               containerPort: {{ $.Values.service.containerPort }}
               protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: {{ $.Values.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
+            periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
+            httpGet:
+              path: {{ $.Values.livenessProbe.http.path }}
+              port: http
+          readinessProbe:
+            initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
+            periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
+            httpGet:
+              path: {{ $.Values.readinessProbe.http.path }}
+              port: http
           volumeMounts:
             - mountPath: /var/www/log4j2.xml
               subPath: log4j2.xml

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -59,12 +59,12 @@ spec:
               name: {{ include "helm_chart.fullname" $ }}-config
             # - mountPath: /elastic/apm/agent
             #   name: elastic-apm-agent
-            # - mountPath: /usr/local/tomcat/conf/log4j2.xml
-            #   subPath: log4j2.xml
-            #   name: {{ include "helm_chart.fullname" $ }}-config
-            # - mountPath: /var/www/seqcoordAppProperties.app.properties
-            #   subPath: seqcoordAppProperties.{{ . }}.app.properties
-            #   name: {{ include "helm_chart.fullname" $ }}-secret
+            - mountPath: /usr/local/tomcat/conf/log4j2.xml
+              subPath: log4j2.xml
+              name: {{ include "helm_chart.fullname" $ }}-config
+            - mountPath: /var/www/seqcoordAppProperties.app.properties
+              subPath: seqcoordAppProperties.{{ . }}.app.properties
+              name: {{ include "helm_chart.fullname" $ }}-secret
       volumes:
         - name: {{ include "helm_chart.fullname" $ }}-config
           configMap:

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -59,12 +59,12 @@ spec:
               name: {{ include "helm_chart.fullname" $ }}-config
             # - mountPath: /elastic/apm/agent
             #   name: elastic-apm-agent
-            - mountPath: /usr/local/tomcat/conf/log4j2.xml
-              subPath: log4j2.xml
-              name: {{ include "helm_chart.fullname" $ }}-config
             - mountPath: /var/www/seqcoordAppProperties.app.properties
               subPath: seqcoordAppProperties.{{ . }}.app.properties
               name: {{ include "helm_chart.fullname" $ }}-secret
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: {{ $.Values.javaOptions }}
       volumes:
         - name: {{ include "helm_chart.fullname" $ }}-config
           configMap:

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - mountPath: /var/www/log4j2.xml
               subPath: log4j2.xml
               name: {{ include "helm_chart.fullname" $ }}-config
-            - mountPath: /var/www/seqcoordAppProperties.app.properties
+            - mountPath: /var/www/borrego.app.properties
               subPath: seqcoordinates.{{ . }}.app.properties
               name: {{ include "helm_chart.fullname" $ }}-secret
           env:

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -69,9 +69,9 @@ spec:
         - name: {{ include "helm_chart.fullname" $ }}-config
           configMap:
             name: {{ include "helm_chart.fullname" $ }}-config
-        - name: {{ include "rcsb-borrego.fullname" $ }}-secret
+        - name: {{ include "helm_chart.fullname" $ }}-secret
           secret:
-            secretName: {{ include "rcsb-borrego.fullname" $ }}-secret
+            secretName: {{ include "helm_chart.fullname" $ }}-secret
           # livenessProbe:
           #   initialDelaySeconds: {{ $.Values.initialLivenessDelaySeconds }}
           #   failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               name: {{ include "helm_chart.fullname" $ }}-secret
             - mountPath: /elastic/apm/agent
               name: elastic-apm-agent
+          resources:
+            {{- toYaml $.Values.resources | nindent 12 }}
           env:
             - name: JDK_JAVA_OPTIONS
               value: {{ $.Values.javaOptions }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -36,13 +36,6 @@ spec:
         - name: {{ $.Values.imagePullSecrets }}
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
-      # initContainers:
-      #   - name: elastic-java-agent
-      #     image: {{ $.Values.elasticAPM.elasticAPMImage }}
-      #     volumeMounts:
-      #       - mountPath: /elastic/apm/agent
-      #         name: elastic-apm-agent
-      #     command: [ 'cp', '-v', '/usr/agent/elastic-apm-agent.jar', '/elastic/apm/agent' ]
       containers:
         - name: {{ $.Chart.Name }}
           securityContext:
@@ -69,13 +62,4 @@ spec:
           #     port: {{ $.Values.service.containerPort }}
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
-          # env:
-          #   - name: ELASTIC_APM_SECRET_TOKEN
-          #     valueFrom:
-          #       secretKeyRef:
-          #         name: {{ include "rcsb-borrego.fullname" $ }}-secret
-          #         key: apm_secret_token
-      # volumes:
-      #   - name: elastic-apm-agent
-      #     emptyDir: { }
 {{- end }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -36,13 +36,13 @@ spec:
         - name: {{ $.Values.imagePullSecrets }}
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
-      initContainers:
-        - name: elastic-java-agent
-          image: {{ $.Values.elasticAPM.elasticAPMImage }}
-          volumeMounts:
-            - mountPath: /elastic/apm/agent
-              name: elastic-apm-agent
-          command: [ 'cp', '-v', '/usr/agent/elastic-apm-agent.jar', '/elastic/apm/agent' ]
+      # initContainers:
+      #   - name: elastic-java-agent
+      #     image: {{ $.Values.elasticAPM.elasticAPMImage }}
+      #     volumeMounts:
+      #       - mountPath: /elastic/apm/agent
+      #         name: elastic-apm-agent
+      #     command: [ 'cp', '-v', '/usr/agent/elastic-apm-agent.jar', '/elastic/apm/agent' ]
       containers:
         - name: {{ $.Chart.Name }}
           securityContext:

--- a/k8s/helm/templates/externalsecret.yaml
+++ b/k8s/helm/templates/externalsecret.yaml
@@ -18,8 +18,8 @@ spec:
     - secretKey: seqcoordinates.a.app.properties
       remoteRef:
         key: parks/{{ .Release.Namespace }}
-        property: seqcoordinates.a.app.properties
+        property: borrego.a.app.properties
     - secretKey: seqcoordinates.b.app.properties
       remoteRef:
         key: parks/{{ .Release.Namespace }}
-        property: seqcoordinates.b.app.properties
+        property: borrego.b.app.properties

--- a/k8s/helm/templates/externalsecret.yaml
+++ b/k8s/helm/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "helm_chart.fullname" . }}
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: rcsb-vault
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "helm_chart.fullname" . }}-secret
+  data:
+    - secretKey: apm_secret_token
+      remoteRef:
+        key: elastic_monitoring/apm_token
+        property: apm_secret_token
+    - secretKey: seqcoordinates.a.app.properties
+      remoteRef:
+        key: parks/{{ .Release.Namespace }}
+        property: seqcoordinates.a.app.properties
+    - secretKey: seqcoordinates.b.app.properties
+      remoteRef:
+        key: parks/{{ .Release.Namespace }}
+        property: seqcoordinates.b.app.properties

--- a/k8s/helm/templates/ingress.yaml
+++ b/k8s/helm/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "helm_chart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.httpIngress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/helm/templates/service.yaml
+++ b/k8s/helm/templates/service.yaml
@@ -1,0 +1,36 @@
+{{- range tuple "a" "b" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm_chart.fullname" $ }}-{{ . }}
+  labels:
+    {{- include "helm_chart.labels" $ | nindent 4 }}
+    rcsb.org/path: {{ . | quote }}
+spec:
+  type: {{ $.Values.service.type }}
+  ports:
+    - port: {{ $.Values.service.port }}
+      targetPort: {{ $.Values.service.containerPort }}
+      protocol: TCP
+  selector:
+    {{- include "helm_chart.selectorLabels" $ | nindent 4 }}
+    rcsb.org/path: {{ . | quote }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm_chart.fullname" . }}
+  annotations:
+    rcsb.org/path-operator-managed: "true"
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.containerPort }}
+      protocol: TCP
+  selector:
+    {{- include "helm_chart.selectorLabels" . | nindent 4 }}

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -29,7 +29,7 @@ image:
   repository: harbor.devops.k8s.rcsb.org/rcsb/rcsb-sequence-coordinates
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "k8s-staging"
+  tag: "production"
 
 imagePullSecrets: "harbor-docker-registry-conf"
 

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -123,3 +123,9 @@ seqcoordAppProperties:
   
 
 javaOptions: "-Xmx20g  -server -DrcsbConfigProfile=file:///var/www -Dlog4j.configurationFile=/var/www/log4j2.xml"
+
+elasticAPM:
+  elasticAPMEnabled: false
+  elasticAPMImage: docker.elastic.co/observability/apm-agent-java:1.51.0
+  elasticAPMServerUrl: http://apm.devops:8200
+  elasticAPMEnvironment: k8s-production

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -29,7 +29,7 @@ image:
   repository: harbor.devops.k8s.rcsb.org/rcsb/rcsb-sequence-coordinates
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "k 8s-staging"
+  tag: "k8s-staging"
 
 imagePullSecrets: "harbor-docker-registry-conf"
 

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -34,14 +34,14 @@ image:
 imagePullSecrets: "harbor-docker-registry-conf"
 
 
-externalSecret:
-  enabled: true
-  secretStoreRefName: "rcsb-vault"
-  data: 
-    - secretKey: apm_secret_token
-      remoteRef:
-        key: elastic_monitoring/apm_token
-        property: apm_secret_token
+# externalSecret:
+#   enabled: true
+#   secretStoreRefName: "rcsb-vault"
+#   data: 
+#     - secretKey: apm_secret_token
+#       remoteRef:
+#         key: elastic_monitoring/apm_token
+#         property: apm_secret_token
 
 deploymentStrategy:
   #https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -95,6 +95,4 @@ seqcoordAppProperties:
     </configuration>
   
 
-
-
-# javaOptions: "-Xmx20g -server -DrcsbConfigProfile=file:///location to the file "absolute"
+javaOptions: "-Xmx20g  -server -DrcsbConfigProfile=file:///var/www -Dlog4j.configurationFile=/var/www/log4j2.xml"

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -21,7 +21,7 @@ livenessProbe:
 initialReadinessDelaySeconds: 120
 readinessProbe:
   http:
-    path: /api/alive
+    path: /actuator/health
   failureThreshold: 6
   periodSeconds: 30
 

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -1,0 +1,82 @@
+# Default values for prerelease.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+revisionHistoryLimit: 3
+
+# vaultSecretStoreName is the name of the ClusterSecretStore resource to pull secret credentials
+vaultSecretStoreName: "rcsb-vault"
+
+# Define container liveness and readiness checks
+# A Pod is considered "live" when it is able to respond to client requests.
+# A Pod is considered "ready" when it has completed initialization and should be one of the backends for a K8s Service resource.
+initialLivenessDelaySeconds: 120
+livenessProbe:
+  http:
+    path: /
+  failureThreshold: 4
+  periodSeconds: 30
+
+initialReadinessDelaySeconds: 120
+readinessProbe:
+  http:
+    path: /api/alive
+  failureThreshold: 6
+  periodSeconds: 30
+
+image:
+  repository: harbor.devops.k8s.rcsb.org/rcsb/rcsb-sequence-coordinates
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "k 8s-staging"
+
+imagePullSecrets: "harbor-docker-registry-conf"
+
+
+externalSecret:
+  enabled: true
+  secretStoreRefName: "rcsb-vault"
+  data: 
+    - secretKey: apm_secret_token
+      remoteRef:
+        key: elastic_monitoring/apm_token
+        property: apm_secret_token
+
+deploymentStrategy:
+  #https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  #Type is either RollingUpdate or Recreate
+  type: "RollingUpdate"
+  #For rolling update, what percentage of total pods can be created above desired amount
+  maxSurge: 25%
+  #For rolling update, what percentage of total pods can be brought down to update
+  maxUnavailable: 25%
+
+podSecurityContext:
+  fsGroup: 33
+  runAsNonRoot: true
+  runAsUser: 33
+  runAsGroup: 33
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
+service:
+  type: ClusterIP
+  port: 80
+  containerPort: 8080
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 8
+    memory: 96Gi
+  requests:
+    cpu: 4
+    memory: 64Gi

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -71,6 +71,33 @@ resources:
     cpu: 4
     memory: 64Gi
 
+ingress:
+  enabled: true
+  className: "haproxy"
+  annotations:
+    cert-manager.io/cluster-issuer: rutgers-acme
+    kubernetes.io/tls-acme: "true"
+    haproxy.org/allow-list: "132.249.210.0/24,128.6.150.0/25,132.249.213.0/24,128.6.158.0/23"
+  hosts:
+    - host: seqcoordinates.k8s.rcsb.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+    - host: seqcoordinates.east.k8s.rcsb.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+    - host: seqcoordinates.west.k8s.rcsb.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - seqcoordinates.k8s.rcsb.org
+        - seqcoordinates.east.k8s.rcsb.org
+        - seqcoordinates.west.k8s.rcsb.org
+      secretName: seqcoordinates.k8s.rcsb.org-tls
+
 # App specific configurations
 seqcoordAppProperties:
   log4j2.xml: |-

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -33,9 +33,6 @@ image:
 
 imagePullSecrets: "harbor-docker-registry-conf"
 
-
-
-
 deploymentStrategy:
   #https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   #Type is either RollingUpdate or Recreate
@@ -73,3 +70,31 @@ resources:
   requests:
     cpu: 4
     memory: 64Gi
+
+# App specific configurations
+seqcoordAppProperties:
+  log4j2.xml: |-
+    <configuration status="WARN" monitorInterval="30">
+      <Properties>
+          <Property name="PATTERN">%d{yyy-MM-dd HH:mm:ss.SSS Z} [%t] %-5level %logger{36} - %msg%n</Property>
+      </Properties>
+      <appenders>
+          <Console name="stdout" target="SYSTEM_OUT" follow="true">
+              <PatternLayout pattern="${PATTERN}"/>
+          </Console>
+      </appenders>
+      <loggers>
+          <root level="info">
+              <appender-ref ref="stdout"/>
+          </root>
+          <!--  Setting special levels for some packages  -->
+          <Logger name="org.mongodb.driver" level="warn" additivity="false">
+              <appender-ref ref="stdout"/>
+          </Logger>
+      </loggers>
+    </configuration>
+  
+
+
+
+# javaOptions: "-Xmx20g -server -DrcsbConfigProfile=file:///location to the file "absolute"

--- a/k8s/helm/values/production.yaml
+++ b/k8s/helm/values/production.yaml
@@ -34,14 +34,7 @@ image:
 imagePullSecrets: "harbor-docker-registry-conf"
 
 
-# externalSecret:
-#   enabled: true
-#   secretStoreRefName: "rcsb-vault"
-#   data: 
-#     - secretKey: apm_secret_token
-#       remoteRef:
-#         key: elastic_monitoring/apm_token
-#         property: apm_secret_token
+
 
 deploymentStrategy:
   #https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy


### PR DESCRIPTION
We're looking to merge in our latest changes to support the deployment of the sequence-coordinates into Kubernetes environment. This PR will add in a helm chart definition to setup the application and dependencies around the service. It will also add in a new CI/CD pipeline to build and push images of the application to our internal harbor container image registry. This CI/CD pipeline will run in parallel with the existing buildlocker artifact process; once we completely migrate over to the Kubernetes environment, we'll clean up and remove the buildlocker pipeline in another PR.

Please let us know if you have any questions about this PR/change. Thanks!